### PR TITLE
Bugfix scipy in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "3.3"
   - "3.4"
   - "2.7"
+before_install:
+  - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
 # command to install dependencies
 install: pip install numpy scipy nose
 # command to run tests


### PR DESCRIPTION
Finally, scipy should work in travis. Unfortunately, travis is not able to use precompiled binaries for scipy in python3, thus I have to use `pip install scipy` which takes ages. But I think it is quite importat especially to test python3, as I usually don't use it.

To be sure, let's wait until the travis CI run for this pull request passed.
