### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ python:
 before_install:
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
 # command to install dependencies
-install: pip install numpy scipy nose python-coveralls nose-cov
+# By default, pip produces much too much output
+# Just silencing int makes travis think it stalled
+# Because of this, we print every 100th line.
+install: pip install numpy scipy nose python-coveralls nose-cov | sed -n '0~100p'
 # command to run tests
 script: nosetests --with-cov --cov PyCircStat


### PR DESCRIPTION
This should fix the output problem with travis: Travis cuts the output after 10000 lines. Unfortunately, if I make the test setup completely quiet, travis thinks the test stalled after getting now output for 10 minutes. Therefore, now I just print every 100th line -- quite a dirty hack, but it seems to work.

I also added a coverage test. Nosetest will show coverage information now after every test, although I think this is not shown in github (but in the travis output).

Best,
  Matthias
