### PR TITLE
Travis with conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,29 @@ python:
   - "2.7"
 before_install:
   - sudo apt-get install -qq libatlas-dev libatlas-base-dev liblapack-dev gfortran
-# command to install dependencies
-# By default, pip produces much too much output
-# Just silencing int makes travis think it stalled
-# Because of this, we print every 100th line.
-install: pip install numpy scipy nose python-coveralls nose-cov | sed -n '0~100p'
+  - sudo apt-get update
+  # You may want to periodically update this, although the conda update
+  # conda line below will keep everything up-to-date.  We do this
+  # conditionally because it saves us some downloading if the version is
+  # the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda update -q --yes conda
+  - conda config --set always_yes yes --set changeps1 no
+  # Useful for debugging any issues with conda
+  - conda info -a
+install:
+  # Replace dep1 dep2 ... with your dependencies
+  - conda create -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy setuptools pip
+  - source activate test-environment
+  - pip install nose nose-cov
+  - conda info -a
 # command to run tests
-script: nosetests --with-cov --cov pycircstat
+script:
+  - nosetests --with-cov --cov pycircstat


### PR DESCRIPTION
I finally managed to make travis work with the miniconda python distribution. This has the huge advantage of having binaries for scipy and numpy. Building scipy from source took a lot of time in each test. Now the tests should run in less than 2 minutes again.

Best,
  Matthias
