### PR TITLE
Use python3 style relative imports

### DIFF
--- a/pycircstat/decorators.py
+++ b/pycircstat/decorators.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 from functools import wraps
 import numpy as np
-from pycircstat import CI
+from . import CI
 
 
 def mod2pi(f):

--- a/pycircstat/descriptive.py
+++ b/pycircstat/descriptive.py
@@ -1,15 +1,17 @@
 """
 Descriptive statistical functions
 """
+from __future__ import absolute_import
+
 from functools import wraps
 import itertools
 
 import numpy as np
 from scipy import stats
 import warnings
-from pycircstat import CI
-from pycircstat.iterators import nd_bootstrap
-from pycircstat.decorators import mod2pi
+from . import CI
+from .iterators import nd_bootstrap
+from .decorators import mod2pi
 
 
 class bootstrap:

--- a/pycircstat/distributions.py
+++ b/pycircstat/distributions.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
+
 from scipy.stats import rv_continuous
 import numpy as np
-from pycircstat import mod2pi
+from . import mod2pi
 import sys
 
 class cardioid_gen(rv_continuous):

--- a/pycircstat/tests.py
+++ b/pycircstat/tests.py
@@ -1,11 +1,13 @@
 """
 Statistical tests
 """
+from __future__ import absolute_import
+
 import numpy as np
 from scipy import misc
 #import warnings
-from pycircstat import descriptive
-from pycircstat import utils
+from . import descriptive
+from . import utils
 
 
 def rayleigh(alpha, w=None, d=None, axis=0):


### PR DESCRIPTION
I changed the imports in all files to import `absolute_import` from `__future__`. This activates the python3 import mechanism. Using this, I was able to get rid of all references to `pycircstat` in the code (would have made renaming the package much easier to begin with and is definitely more elegant).

Signed-off-by: Matthias Kümmerer matthias@matthias-k.org
