### PR TITLE
Fix sphinx documentation for distributions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,10 +15,12 @@
 import sys
 import os
 import mock
- 
-MOCK_MODULES = ['numpy', 'scipy', 'matplotlib', 'matplotlib.pyplot', 'scipy.stats']
+
+MOCK_MODULES = ['numpy', 'scipy', 'matplotlib', 'matplotlib.pyplot']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.Mock()
+
+sys.modules['scipy.stats'] = mock.Mock(rv_continuous=object)
 
 #import sphinx_bootstrap_theme
 


### PR DESCRIPTION
This should fix the problem @fabiansinz told me about. We make use of mock modules to make sure the documentation compiles e.g. on the readthedocs servers without scipy etc. installed. This mechanism by default disables documentation for all classes that inherit from one of these mocked modules. One has to adapt `docs/conf.py` for each of the classes that need to be interitable; in this case:

```
sys.modules['scipy.stats'] = mock.Mock(rv_continuous=object)
```

We have to keep in mind that we might have do adapt the configuration further in future. Unfortunately build_sphinx does not fail, it just excludes the classes from the documentation.
