### PR TITLE
Updated _corr and test_corrcl

### DIFF
--- a/pycircstat/descriptive.py
+++ b/pycircstat/descriptive.py
@@ -565,8 +565,9 @@ def axial(alpha, p=1):
 
 
 def _corr(x, y, axis=0):
-    np.sum((x - x.mean(axis=axis, keepdims=True))  * (y - y.mean(axis=axis, keepdims=True)), axis=axis) \
-    / np.std(x, axis=axis) / np.std(y, axis=axis) / x.shape[axis]
+    return np.sum((x - x.mean(axis=axis, keepdims=True))  * \
+                  (y - y.mean(axis=axis, keepdims=True)), axis=axis) \
+            / np.std(x, axis=axis) / np.std(y, axis=axis) / x.shape[axis]
 
 
 @bootstrap(1, 'linear')

--- a/pycircstat/descriptive.py
+++ b/pycircstat/descriptive.py
@@ -565,8 +565,8 @@ def axial(alpha, p=1):
 
 
 def _corr(x, y, axis=0):
-        return np.sum((x - x.mean(axis=axis))*( y - y.mean(axis=axis))) \
-                / np.std(x, axis=axis) / np.std(y, axis=axis) / (x.shape[axis]-1)
+    np.sum((x - x.mean(axis=axis, keepdims=True))  * (y - y.mean(axis=axis, keepdims=True)), axis=axis) \
+    / np.std(x, axis=axis) / np.std(y, axis=axis) / x.shape[axis]
 
 
 @bootstrap(1, 'linear')

--- a/pycircstat/descriptive.py
+++ b/pycircstat/descriptive.py
@@ -564,11 +564,9 @@ def axial(alpha, p=1):
     return alpha * p % (2 * np.pi)
 
 
-def _corr(x, y, axis=None):
-    return np.mean(x * y,
-                   axis=axis) / np.std(x,
-                                       axis=axis) / np.std(y,
-                                                           axis=axis)
+def _corr(x, y, axis=0):
+        return np.sum((x - x.mean(axis=axis))*( y - y.mean(axis=axis))) \
+                / np.std(x, axis=axis) / np.std(y, axis=axis) / (x.shape[axis]-1)
 
 
 @bootstrap(1, 'linear')

--- a/tests/test_descriptive.py
+++ b/tests/test_descriptive.py
@@ -347,7 +347,7 @@ def test_corrcc_ci_2d():
 def test_corrcl():
     data1 = np.random.rand(50000) * 2 * np.pi
     data2 = np.random.randn(50000)
-    assert_allclose(pycircstat.corrcc(data1, data2),
+    assert_allclose(pycircstat.corrcl(data1, data2),
                     0., rtol=3 * 1e-2, atol=3 * 1e-2)
 
 


### PR DESCRIPTION
While using the "corrcl" function, I was obtaining correlation values >1 (around 4 and 5 actually). I modified the _corr function and my multiple correlations between angle vs linear datasets is now between 0 and 1.

There was a typo in the test_corrcl function that used corrcc instead of corrcl for the test. This gave unexpected correlation values. After fixing this and the corrcl function itself in descriptive.py, the function should work as intended.