### PR TITLE
Scipy 1.3.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+dist: xenial
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "2.7"
 before_install:
   - sudo apt-get -y update

--- a/pycircstat/tests.py
+++ b/pycircstat/tests.py
@@ -6,7 +6,6 @@ import warnings
 from nose.tools import nottest
 
 import numpy as np
-from scipy import misc
 from scipy import stats
 # import warnings
 from . import descriptive, swap2zeroaxis
@@ -120,7 +119,7 @@ def omnibus(alpha, w=None, sz=np.radians(1), axis=None):
 
     if np.any(~idx50):
         pval[~idx50] = 2 ** (1 - n[~idx50]) * (n[~idx50] - \
-                                               2 * m[~idx50]) * misc.comb(n[~idx50], m[~idx50])
+                                               2 * m[~idx50]) * special.comb(n[~idx50], m[~idx50])
 
     return pval.squeeze(), m
 


### PR DESCRIPTION
Replaced deprecated alias `scipy.misc.comb` with `scipy.special.comb`.