### PR TITLE
Include LICENSE in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Listing `LICENSE` in `MANIFEST.in` will ensure it's included in the source distribution, which is a good idea (and required e.g. for packages on `conda-forge`)