### PR TITLE
Use inspect library to get input argument names

### DIFF
--- a/pycircstat/decorators.py
+++ b/pycircstat/decorators.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
 from functools import wraps
+from inspect import getfullargspec
+import sys
 import numpy as np
 from . import CI
 from decorator import decorator
@@ -36,7 +38,10 @@ def mod2pi(f):
 
 
 def get_var(f, varnames, args, kwargs):
-    fvarnames = f.__code__.co_varnames
+    if sys.version_info[0] > 2:
+        fvarnames = getfullargspec(f).args
+    else:
+        fvarnames = f.__code__.co_varnames
 
     var_idx = []
     kwar_keys = []

--- a/pycircstat/descriptive.py
+++ b/pycircstat/descriptive.py
@@ -5,7 +5,9 @@ from __future__ import absolute_import
 
 from functools import wraps
 import itertools
+import sys
 from decorator import decorator
+from inspect import getfullargspec
 
 import numpy as np
 from scipy import stats
@@ -34,7 +36,10 @@ class bootstrap:
         self.scale = scale
 
     def _get_var(self, f, what, default, args, kwargs, remove=False):
-        varnames = f.__code__.co_varnames
+        if sys.version_info[0] > 2:
+            varnames = getfullargspec(f).args
+        else:
+            varnames = f.__code__.co_varnames
 
         if what in varnames:
             what_idx = varnames.index(what)


### PR DESCRIPTION
For compatibility with python 3, I'm using inspect.getfullargspec to list the input arguments. I added an if-else to check for python version, in case people are still running Python 2.  Tested on my local machine.